### PR TITLE
Updated fermipy dependence.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ setup(
         'astropy >= 1.2.1',
         'matplotlib >= 1.5.0',
         'scipy >= 0.14',
-        'fermipy >= 0.17.1',
+        'fermipy >= 0.17.2',
         'pyyaml',
         'healpy',
-        'dmsky >= 0.2.1'
+        'dmsky >= 0.2.2'
     ],
     extras_require=dict(
         all=[],


### PR DESCRIPTION
Updated setup.py to require fermipy 0.17.2 and dmsky 0.2.2 which are needed to run the pipeline properly.